### PR TITLE
Déplacement des redirections

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,6 +1,5 @@
 import { createPool, testConnection } from '$lib/server/db';
 import { getUserinfo } from '$lib/server/account';
-import { redirect } from '@sveltejs/kit';
 
 export const pool = createPool();
 testConnection(pool);
@@ -8,16 +7,7 @@ testConnection(pool);
 export async function handle({ event, resolve }) {
 	event.locals.pool = pool;
 	event.locals.userInfo = await getUserinfo(event);
-
-	if (event.url.pathname !== '/login' && event.url.pathname !== '/register') {
-		if (!event.locals.userInfo) throw redirect(308, '/login');
-	} else {
-		if (event.locals.userInfo) throw redirect(303, '/');
-	};
-
-	const response = await resolve(event);
-
-	return response;
+	return await resolve(event);
 }
 
 export function handleError({ error }) {

--- a/src/routes/login/+page.server.js
+++ b/src/routes/login/+page.server.js
@@ -6,6 +6,13 @@ import {
     generateUuid,
     setSession
 } from '$lib/server/account';
+import {redirect} from "@sveltejs/kit";
+
+export const load = async (serverLoadEvent) => {
+    const {locals} = serverLoadEvent;
+    if (locals.userInfo)
+        throw redirect(308, '/');
+}
 
 /** @type {import('./$types').Actions} */
 export const actions = {

--- a/src/routes/parts/+page.server.js
+++ b/src/routes/parts/+page.server.js
@@ -4,9 +4,8 @@ import {redirect} from "@sveltejs/kit";
 export const load = async (serverLoadEvent) => {
     const user = await getUserinfo(serverLoadEvent);
     if (user == null)
-        throw redirect(303, '/');
+        throw redirect(303, '/login');
     user["parts"] = await getArchiveParts(user["user_id"]);
-    console.log(user["parts"])
     return {
         'user': user
     }

--- a/src/routes/register/+page.server.js
+++ b/src/routes/register/+page.server.js
@@ -6,7 +6,13 @@ import {
 	createUser,
 	generateUuid,
 	setSession
-} from '../../lib/server/account.js';
+} from '$lib/server/account.js';
+
+export const load = async (serverLoadEvent) => {
+	const {locals} = serverLoadEvent;
+	if (locals.userInfo)
+		throw redirect('/');
+}
 
 export const actions = {
 	default: async ({ request, locals, cookies }) => {
@@ -21,9 +27,9 @@ export const actions = {
 			return fail(400, errors);
 		}
 
-		const hashedPasword = await hashPassword(password, saltRounds);
+		const hashedPassword = await hashPassword(password, saltRounds);
 
-		({ errors, user_id } = await createUser(locals, username, hashedPasword));
+		({ errors, user_id } = await createUser(locals, username, hashedPassword));
 
 		if (Object.keys(errors).length) {
 			return fail(400, errors);


### PR DESCRIPTION
Déplacements des redirections de `hook.server.js` vers les `+page.server.js` des pages qui sont concernées par la redirection. Cela a été fait, car il y avait des problèmes avec la cache du navigateur ce qui conduisait à des redirections non prévues. Par exemple, l'utilisateur était redirigé vers la page de login alors qu'il était connecté.

De plus, maintenant, la page d'accueil est accessible par n'importe quel type d'utilisateur (connecté ou pas), car la page d'accueil sera sûrement la vitrine du site.