### PR TITLE
fix: Redirect bug for logged-in users

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -9,9 +9,15 @@ export async function handle({ event, resolve }) {
 	event.locals.pool = pool;
 	event.locals.userInfo = await getUserinfo(event);
 
-	// if user is not logged in, redirect him to /login
+
+	// if user is not logged in, redirect him to /login and allow him to navigate to /register
 	if (!event.locals.userInfo && event.url.pathname !== '/login' && event.url.pathname !== '/register') {
 		throw redirect(307, '/login');
+	}
+
+	// if user is logged in and navigate to /login or /register, redirect him to /
+	if (event.locals.userInfo && (event.url.pathname == '/login' || event.url.pathname == '/register')) {
+		throw redirect(307, '/');
 	}
 	const response = await resolve(event);
 

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -16,7 +16,7 @@ export async function handle({ event, resolve }) {
 	}
 
 	// if user is logged in and navigate to /login or /register, redirect him to /
-	if (event.locals.userInfo && (event.url.pathname == '/login' || event.url.pathname == '/register')) {
+	if (event.locals.userInfo && (event.url.pathname === '/login' || event.url.pathname === '/register')) {
 		throw redirect(307, '/');
 	}
 	const response = await resolve(event);

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -9,12 +9,10 @@ export async function handle({ event, resolve }) {
 	event.locals.pool = pool;
 	event.locals.userInfo = await getUserinfo(event);
 
-	if (event.url.pathname !== '/login' && event.url.pathname !== '/register') {
-		if (!event.locals.userInfo) throw redirect(308, '/login');
-	} else {
-		if (event.locals.userInfo) throw redirect(303, '/');
-	};
-
+	// if user is not logged in, redirect him to /login
+	if (!event.locals.userInfo && event.url.pathname !== '/login' && event.url.pathname !== '/register') {
+		throw redirect(307, '/login');
+	}
 	const response = await resolve(event);
 
 	return response;


### PR DESCRIPTION
**Description:**
Modified redirect status code from 8 (permanent) to 7 (temporary) to prevent incorrect redirection of logged-in users to the login page. Users can now navigate between pages without encountering redirection issues. 

**Root Cause:**
The previous redirect status code of 8, intended for permanent redirects, caused caching issues in browsers. When a user attempted to access the `/` route, the browser would immediately redirect to `/login` without sending a request to the server for the `/` route, treating the redirect as permanent.

**Resolution:**
Altered the redirect status code from 8 to 7, ensuring that browsers correctly handle the redirect as temporary and send a request to the server for the `/` route.