### PR TITLE
FIX: utilisateurs non connectés redirigés `/` au lieu de `/login`

### DIFF
--- a/src/routes/parts/+page.server.js
+++ b/src/routes/parts/+page.server.js
@@ -2,11 +2,13 @@ import {getArchiveParts, getUserinfo} from "$lib/server/account.js";
 import {redirect} from "@sveltejs/kit";
 
 export const load = async (serverLoadEvent) => {
-    const user = await getUserinfo(serverLoadEvent);
-    if (user == null)
-        throw redirect(303, '/');
-    user["parts"] = await getArchiveParts(user["user_id"]);
-    console.log(user["parts"])
+    const {locals} = serverLoadEvent;
+    if (!locals.userInfo)
+        throw redirect(303, '/login');
+    const user = {
+        user_id: locals.userInfo.user_id
+    };
+    user.parts = await getArchiveParts(locals.userInfo.user_id);
     return {
         'user': user
     }

--- a/src/routes/parts/+page.svelte
+++ b/src/routes/parts/+page.svelte
@@ -51,7 +51,8 @@
                 {/each}
             </div>
         {:else}
-            <h2>Il est temps de faire une partie</h2>
+            <h2>It's time to make some parts !</h2>
+            <br>
         {/if}
     </div>
 </div>


### PR DESCRIPTION
## Fix :
- Lorsqu'un utilisateur non-connecté essayait d'accéder à la page, celle-ci tentait de le rediriger vers la page d'accueil au lieu de la page de login.
- Le message pour dire que l'utilisateur n'avait pas encore fait de partie était en français, il est désormais en anglais.
- Une fonction qui faisait un appel à la base de données était utilisée pour récupérer les données de l'utilisateur, alors qu'elles étaient déjà disponibles dans les données locales.