### PR TITLE
WEB: changement message erreur authentification

### DIFF
--- a/src/routes/login/+page.server.js
+++ b/src/routes/login/+page.server.js
@@ -15,16 +15,16 @@ export const actions = {
         if (!await checkIfUsernameExists(username)) {
             return {
                 success: false,
-                message: 'Username does not exist'
+                message: 'Username or password incorrect'
             };
-        };
+        }
 
         if (!await checkIfPasswordIsCorrect(username, password)) {
             return {
                 success: false,
-                message: 'Incorrect password'
+                message: 'Username or password incorrect'
             };
-        };
+        }
 
         const userId = await getUserId(locals, username);
         const uuid = generateUuid();


### PR DESCRIPTION
## Description : 
Changement du message pour dire à l'utilisateur que le mot de passe et/ou le nom d'utilisateur afin d'avoir un même message pour les 2 dans le but d'éviter une faille de sécurité en disant à un potentiel utilisateur intru ce qui ne va pas.

## Note :
Normalement, cette PR devait include un cryptage des mots de passe côté client afin de ne pas envoyer le mot de passe en clair, mais après réfléxion, cette étape est inutile. Car le mot de passe crypté sera utilisé directement pour la comparaison des hash (*avec ou sans sallage*), donc un utilisateur qui arrive à avoir le mot de passe non crypté arrivera à se faire passer pour un autre utilisateur, même si le mot de passe est crypté.