### PR TITLE
Ajout `ON DELETE CASCADE` aux tables liées aux parties

### DIFF
--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -49,8 +49,8 @@ CREATE TABLE IF NOT EXISTS archive_parts (
     duration_ms BIGINT,
     date TIMESTAMPTZ,
     CONSTRAINT pk_archive_parts PRIMARY KEY (part_id),
-    CONSTRAINT fk_archive_parts_users_winner FOREIGN KEY (winner) REFERENCES users(user_id),
-    CONSTRAINT fk_archive_parts_Users_loser FOREIGN KEY (loser) REFERENCES users(user_id),
+    CONSTRAINT fk_archive_parts_users_winner FOREIGN KEY (winner) REFERENCES users(user_id) ON DELETE CASCADE,
+    CONSTRAINT fk_archive_parts_Users_loser FOREIGN KEY (loser) REFERENCES users(user_id) ON DELETE CASCADE,
     CONSTRAINT archive_parts_participants CHECK (winner != loser),
     CONSTRAINT archive_parts_duration CHECK (duration_ms > 0)
 );
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS part_proposal (
     opponent_id INT,
     accepted BOOLEAN NULL DEFAULT NULL,
     CONSTRAINT pk_part_proposal PRIMARY KEY (requester_id),
-    CONSTRAINT fk_part_proposal_requester FOREIGN KEY (requester_id) REFERENCES users(user_id),
-    CONSTRAINT fk_part_proposal_participant FOREIGN KEY (opponent_id) REFERENCES users(user_id),
+    CONSTRAINT fk_part_proposal_requester FOREIGN KEY (requester_id) REFERENCES users(user_id) ON DELETE CASCADE,
+    CONSTRAINT fk_part_proposal_participant FOREIGN KEY (opponent_id) REFERENCES users(user_id) ON DELETE CASCADE,
     CONSTRAINT part_proposal_requester_participant CHECK (requester_id != opponent_id)
 );


### PR DESCRIPTION
Cela a été fait dans le but de pouvoir supprimer un utilisateur de la base de données sans devoir, manuellement, supprimer toutes les parties qu'ils avaient faites dans le passé.