### PR TITLE
Ajout de rôles

### DIFF
--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS roles (
 CREATE TABLE IF NOT EXISTS users_roles (
   user_id INT NOT NULL,
   role_id INT NOT NULL,
+  CONSTRAINT pk_users_roles PRIMARY KEY (user_id, role_id),
   FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
   FOREIGN KEY (role_id) REFERENCES roles(role_id) ON DELETE CASCADE
 );

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS roles (
 CREATE TABLE IF NOT EXISTS users_roles (
   user_id INT NOT NULL,
   role_id INT NOT NULL,
-  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
   FOREIGN KEY (role_id) REFERENCES roles(role_id) ON DELETE CASCADE
 );
 

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -9,6 +9,18 @@ CREATE TABLE IF NOT EXISTS users (
   password VARCHAR(255) NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS roles (
+  role_id SERIAL PRIMARY KEY,
+  name VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users_roles (
+  user_id INT NOT NULL,
+  role_id INT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+  FOREIGN KEY (role_id) REFERENCES roles(role_id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS sessions (
   session_id SERIAL PRIMARY KEY,
   user_id INT NOT NULL,
@@ -35,11 +47,6 @@ CREATE TABLE IF NOT EXISTS friends (
     FOREIGN KEY (user_id_1) REFERENCES users(user_id) ON DELETE CASCADE,
     FOREIGN KEY (user_id_2) REFERENCES users(user_id) ON DELETE CASCADE,
     CONSTRAINT friends_users CHECK (user_id_1 != user_id_2)
-);
-
-CREATE TABLE IF NOT EXISTS admins (
-  user_id INT NOT NULL PRIMARY KEY,
-  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS archive_parts (

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -25,7 +25,6 @@ VALUES
 INSERT INTO users_roles (user_id, role_id)
 VALUES
   (1, 1),
-  (1, 1),
   (2, 1),
   (3, 1),
   (4, 1),

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -16,6 +16,11 @@ VALUES
   ('Irene', '$2b$10$Uo.576WqbP7l7zcHr2SN7./Dw/iEq9HyZ/7wGVh/pifGSCviyu6Sq'),
   ('Quinn', '$2b$10$d/fCrQl3RBSV7BaSJDq0yel0X2lCoNgo5fpmhxdvPbscek8BKUcNO');
 
+INSERT INTO roles (role_id, name)
+VALUES
+  (1, 'user'),
+  (2, 'admin');
+
 INSERT INTO sessions (user_id, uuid, expires_at)
 VALUES
   (1, 'b531c4e2-3459-4e83-955c-942f71d52133', '2023-10-15 08:43:46.562+00'),
@@ -23,10 +28,6 @@ VALUES
   (3, 'b531c4e2-3459-4e83-955c-942f71d52135', '2023-10-17 08:43:46.562+00'),
   (4, 'b531c4e2-3459-4e83-955c-942f71d52136', '2023-10-18 08:43:46.562+00'),
   (5, 'b531c4e2-3459-4e83-955c-942f71d52137', '2023-10-19 08:43:46.562+00');
-
-INSERT INTO admins (user_id)
-VALUES
-  (1);
 
 INSERT INTO archive_parts (winner, loser, duration_ms, date)
 VALUES

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -18,8 +18,23 @@ VALUES
 
 INSERT INTO roles (role_id, name)
 VALUES
+  (0, 'suspended'),
   (1, 'user'),
   (2, 'admin');
+
+INSERT INTO users_roles (user_id, role_id)
+VALUES
+  (1, 1),
+  (1, 1),
+  (2, 1),
+  (3, 1),
+  (4, 1),
+  (5, 1),
+  (6, 1),
+  (7, 1),
+  (8, 1),
+  (9, 1),
+  (10, 1);
 
 INSERT INTO sessions (user_id, uuid, expires_at)
 VALUES

--- a/src/lib/server/account.js
+++ b/src/lib/server/account.js
@@ -110,13 +110,13 @@ export async function getUserinfo({ cookies, locals }) {
 	return rows[0];
 }
 
-export async function checkIfUsernameExists(username) {
-	const { rows } = await pool.query({
-		text: 'SELECT EXISTS (SELECT 1 FROM users WHERE username = $1) AS exists',
-		values: [username]
+export async function getUserRoles(userId) {
+	const {rows} = await pool.query({
+		text: 'SELECT array_agg(roles.name) FROM users_roles AS roles WHERE user_id = $1',
+		values: [userId]
 	});
 
-	return rows[0].exists;
+	return rows[0];
 }
 
 export async function checkIfPasswordIsCorrect(username, password) {

--- a/src/lib/server/account.js
+++ b/src/lib/server/account.js
@@ -121,7 +121,7 @@ export async function getUserRoles(userId) {
         values: [userId]
     });
 
-	return rows[0].array_agg;
+	return rows[0].array_agg ? rows[0].array_agg : [];
 }
 
 export async function checkIfPasswordIsCorrect(username, password) {

--- a/src/lib/server/account.js
+++ b/src/lib/server/account.js
@@ -141,16 +141,6 @@ export async function getUserId(locals, username) {
 
 	return rows[0].id;
 }
-
-export async function checkIfAdmin({ locals }) {
-	if (!locals.userInfo) return false;
-	const { rows } = await locals.pool.query({
-		text: 'SELECT * FROM admins WHERE user_id = $1',
-		values: [locals.userInfo.user_id]
-	});
-
-	return rows[0];
-}
   
 export async function getArchiveParts(userId) {
 	const {rows} = await pool.query({

--- a/src/lib/server/account.js
+++ b/src/lib/server/account.js
@@ -111,12 +111,17 @@ export async function getUserinfo({ cookies, locals }) {
 }
 
 export async function getUserRoles(userId) {
-	const {rows} = await pool.query({
-		text: 'SELECT array_agg(roles.name) FROM users_roles AS roles WHERE user_id = $1',
-		values: [userId]
-	});
+    const {rows} = await pool.query({
+        text: `
+            SELECT array_agg(roles.name)
+            FROM users_roles
+            JOIN roles ON users_roles.role_id = roles.role_id
+            WHERE users_roles.user_id = $1
+        `,
+        values: [userId]
+    });
 
-	return rows[0];
+	return rows[0].array_agg;
 }
 
 export async function checkIfPasswordIsCorrect(username, password) {

--- a/src/lib/server/account.js
+++ b/src/lib/server/account.js
@@ -65,6 +65,11 @@ export async function createUser(locals, username, hashedPassword) {
 		values: [username, hashedPassword]
 	});
 
+	await locals.pool.query({
+		text: 'INSERT INTO users_roles (user_id, role_id) VALUES ($1, 1)',
+		values: [query.rows[0].user_id]
+	});
+
 	return {
 		user_id: query.rows[0].user_id
 	};

--- a/src/routes/admin/+page.server.js
+++ b/src/routes/admin/+page.server.js
@@ -1,7 +1,13 @@
-import {checkIfAdmin} from "$lib/server/account.js";
+import {getUserRoles} from "$lib/server/account.js";
 import {redirect} from "@sveltejs/kit";
 
 export const load = async (serverLoadEvent) => {
-    if(!await checkIfAdmin(serverLoadEvent))
-        throw redirect(308, '/');
+    const {locals} = serverLoadEvent;
+    if (!locals.userInfo)
+        throw redirect(303, '/login');
+
+    const roles = await getUserRoles(locals.userInfo.user_id);
+
+    if (!roles.includes('admin'))
+        throw redirect(303, '/');
 }


### PR DESCRIPTION
## Description
Cette US permet l'ajout de rôles. Elle remplace la fonctionnalité des admins et supprime aussi toute association à sa table.

## Fonctionnement
Deux nouvelles tables ont été ajoutées, `roles` et `users_roles`.

`roles` contient les rôles ainsi que leur nom.
`users_roles` est une relation many-to-many, qui fait que chaque user peut avoir plusieurs rôles.

## Remplacement des admins
La table `admins` a été supprimée, car il y a, à présent, un rôle `admin`. Quiconque a ce rôle est désormais considéré administrateur et peut donc accéder aux ressources `/admin`.

## Rôles par défaut
Il y a 3 rôles par défaut qui doivent toujours garder les mêmes `role_id` et `name`. Il est bien entendu possible d'en ajouter des nouveaux. Chaque nouvel utilisateur aura le rôle `user`par défaut.

| role_id  | name | description |
| ------------- | ------------- | ------------- |
| 0  | suspended  | Utilisateurs suspendus pour manquement aux règles. |
| 1  | user  | Utilisateur basique. |
| 2  | admin  | Utilisateur administrateur. |