### PR TITLE
feature(layout): Add global css

### DIFF
--- a/services/web/svelte-kit/package-lock.json
+++ b/services/web/svelte-kit/package-lock.json
@@ -8,9 +8,9 @@
 			"name": "pocketbot",
 			"version": "0.0.1",
 			"dependencies": {
-				"svelte-routing": "^2.10.0",
 				"argon2": "^0.31.2",
-				"pg": "^8.11.3"
+				"pg": "^8.11.3",
+				"svelte-routing": "^2.10.0"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.28.1",

--- a/services/web/svelte-kit/src/app.css
+++ b/services/web/svelte-kit/src/app.css
@@ -1,3 +1,91 @@
-@tailwind base;
+/* @tailwind base;
 @tailwind components;
-@tailwind utilities;
+@tailwind utilities; */
+
+:root {
+--background-1: #252b38;
+--background-2: #1f2937;
+--background-3: #000b1d;
+--border-color: rgb(55 65 81);
+
+--shadow-color: rgba(0, 0, 0, 0.2);
+--shadow-color-light: rgba(255, 255, 255, 0.2);
+--shadow: 0 1px 6px rgba(0, 0, 0, 0.12), 0 1px 4px rgba(0, 0, 0, 0.24);
+
+--red: rgb(220 38 38);
+--green: rgb(22 163 74);
+--blue: rgb(59 130 246);
+
+--text-size: 13pt;
+--text-color: rgb(255, 255, 255);
+--text-font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+}
+
+html {
+    color: var(--text-color);
+    font-family: var(--text-font);
+    font-size: var(--text-size);
+}
+
+body {
+    background-color: var(--background-1);
+}
+
+h1 {
+    font-size: 30px;
+    line-height: 36px;
+    font-weight: 700;    
+}
+
+h2 {
+    font-size: 24px;
+    line-height: 28px;
+}
+
+form {
+    border-width: 1px;
+    border-color: var(--border-color);
+    background-color: var(--background-2);
+    border-radius: 8px;
+    padding: 15px;
+}
+
+a { color: var(--text-color); }
+
+a:hover {
+    text-decoration-line: underline;
+    color: var(--blue)
+}
+
+.hidden { display: none; }
+
+button {
+    height: 35px;
+    border-radius: 17.5px;
+    margin: 5px;
+    outline: none;
+    border: none;
+    color: var(--text-color);
+    font-family: var(--text-font);
+    padding: 0 15px;
+    background-repeat: no-repeat;
+    cursor: pointer;
+    box-sizing: border-box;
+    background-color: var(--blue);
+}
+
+input[type=checkbox] {height: 0;width: 0;visibility: hidden;position: absolute;}
+
+input[type=email], input[type=password], input[type=text] {
+    margin: 5px;
+    text-align: left;
+    cursor: text;
+    background-color: var(--shadow-color-light);
+    border-radius: 8px;
+    height: 40px;
+    border: rgba(0, 0, 0, 0) 1px solid;
+    color: var(--text-color);
+}
+
+input[type=email]:focus, input[type=password]:focus, input[type=text]:focus { border: var(--text-color) 1px solid;}
+ul {list-style: none;}

--- a/services/web/svelte-kit/src/app.css
+++ b/services/web/svelte-kit/src/app.css
@@ -3,89 +3,95 @@
 @tailwind utilities; */
 
 :root {
---background-1: #252b38;
---background-2: #1f2937;
---background-3: #000b1d;
---border-color: rgb(55 65 81);
-
---shadow-color: rgba(0, 0, 0, 0.2);
---shadow-color-light: rgba(255, 255, 255, 0.2);
---shadow: 0 1px 6px rgba(0, 0, 0, 0.12), 0 1px 4px rgba(0, 0, 0, 0.24);
-
---red: rgb(220 38 38);
---green: rgb(22 163 74);
---blue: rgb(59 130 246);
-
---text-size: 13pt;
---text-color: rgb(255, 255, 255);
---text-font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
-}
-
-html {
-    color: var(--text-color);
-    font-family: var(--text-font);
-    font-size: var(--text-size);
-}
-
-body {
-    background-color: var(--background-1);
-}
-
-h1 {
-    font-size: 30px;
-    line-height: 36px;
-    font-weight: 700;    
-}
-
-h2 {
-    font-size: 24px;
-    line-height: 28px;
-}
-
-form {
-    border-width: 1px;
-    border-color: var(--border-color);
-    background-color: var(--background-2);
-    border-radius: 8px;
-    padding: 15px;
-}
-
-a { color: var(--text-color); }
-
-a:hover {
-    text-decoration-line: underline;
-    color: var(--blue)
-}
-
-.hidden { display: none; }
-
-button {
-    height: 35px;
-    border-radius: 17.5px;
-    margin: 5px;
-    outline: none;
-    border: none;
-    color: var(--text-color);
-    font-family: var(--text-font);
-    padding: 0 15px;
-    background-repeat: no-repeat;
-    cursor: pointer;
-    box-sizing: border-box;
-    background-color: var(--blue);
-}
-
-input[type=checkbox] {height: 0;width: 0;visibility: hidden;position: absolute;}
-
-input[type=email], input[type=password], input[type=text] {
-    margin: 5px;
-    text-align: left;
-    cursor: text;
-    background-color: var(--shadow-color-light);
-    border-radius: 8px;
-    height: 40px;
-    border: rgba(0, 0, 0, 0) 1px solid;
-    color: var(--text-color);
-}
-
-input[type=email]:focus, input[type=password]:focus, input[type=text]:focus { border: var(--text-color) 1px solid;}
-ul {list-style: none;}
+    --background-1: #252b38;
+    --background-2: #1f2937;
+    --background-3: #000b1d;
+    --border-color: rgb(55 65 81);
+    
+    --shadow-color: rgba(0, 0, 0, 0.2);
+    --shadow-color-light: rgba(255, 255, 255, 0.2);
+    --shadow: 0 1px 6px rgba(0, 0, 0, 0.12), 0 1px 4px rgba(0, 0, 0, 0.24);
+    
+    --red: rgb(220 38 38);
+    --green: rgb(22 163 74);
+    --blue: rgb(59 130 246);
+    
+    --text-size: 13pt;
+    --text-color: rgb(255, 255, 255);
+    --text-font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    }
+    
+    html {
+        color: var(--text-color);
+        font-family: var(--text-font);
+        font-size: var(--text-size);
+    }
+    
+    body {
+        background-color: var(--background-1);
+    }
+    
+    h1 {
+        font-size: 1.8em;
+        line-height: 1.8em;
+        font-weight: 700;
+    }
+    
+    h2 {
+        font-size: 1.5em;
+        line-height: 1.75em;
+    }
+    
+    form {
+        border-width: 1px;
+        border-color: var(--border-color);
+        background-color: var(--background-2);
+        border-radius: 0.5em;
+        padding: 1em;
+    }
+    
+    a { color: var(--text-color); }
+    
+    a:hover {
+        text-decoration-line: underline;
+        color: var(--blue)
+    }
+    
+    .hidden { display: none; }
+    
+    button {
+        height: 2.2em;
+        border-radius: 1em;
+        margin: 0.3em;
+        outline: none;
+        border: none;
+        color: var(--text-color);
+        font-family: var(--text-font);
+        padding: 0 1em;
+        background-repeat: no-repeat;
+        cursor: pointer;
+        box-sizing: border-box;
+        background-color: var(--blue);
+    }
+    
+    input[type=checkbox] {height: 0;width: 0;visibility: hidden;position: absolute;}
+    
+    input[type=email], input[type=password], input[type=text] {
+        margin: 0.3em;
+        padding: 0.3em;
+        text-align: left;
+        cursor: text;
+        background-color: var(--shadow-color-light);
+        border-radius: 0.5em;
+        height: 2.5em;
+        border: rgba(0, 0, 0, 0) 1px solid;
+        color: var(--text-color);
+    }
+    
+    ::placeholder {
+        color: var(--text-color);
+        opacity: 0.7;
+    }
+    
+    input[type=email]:focus, input[type=password]:focus, input[type=text]:focus { border: var(--text-color) 1px solid;}
+    ul {list-style: none;}

--- a/services/web/svelte-kit/src/routes/css-template/+page.server.js
+++ b/services/web/svelte-kit/src/routes/css-template/+page.server.js
@@ -1,0 +1,9 @@
+import { getUserRoles } from '$lib/server/account.js';
+import { redirect } from '@sveltejs/kit';
+
+
+export async function load({locals}) {
+    const roles = await getUserRoles(locals.userInfo.user_id);
+    if (!roles.includes('admin'))
+ 	   throw redirect(307, '/');
+}

--- a/services/web/svelte-kit/src/routes/css-template/+page.svelte
+++ b/services/web/svelte-kit/src/routes/css-template/+page.svelte
@@ -1,0 +1,31 @@
+<div>
+    <div id="mainDiv">
+        <h1>Main title</h1>
+        <h2>Second title</h2>
+        <form id="formTest">
+            <label for="txt">Label text</label>
+            <input type="text" placeholder="the placeholder">
+            <br>
+            <button type="submit" id="basic-button">basic button</button>
+            <button type="submit" id="green-button">green button</button>
+            <button type="submit" id="red-button">red button</button>
+        </form>
+    </div>
+    <a href="tmp">Its a link</a>
+</div>
+
+<style>
+    div {
+        background-color: var(--background-3);
+        text-align: center
+    }
+    #green-button {
+        background-color: var(--green);
+    }
+    #red-button {
+        background-color: var(--red);
+    }
+    form {
+        display: inline-block;
+    }
+</style>

--- a/services/web/svelte-kit/tests/template.test.js
+++ b/services/web/svelte-kit/tests/template.test.js
@@ -1,0 +1,131 @@
+import { expect, test } from "@playwright/test";
+import pkg from 'pg';
+const { Pool } = pkg;
+
+const testCSSProperties = async (element, properties) => {
+    for (const [property, value] of Object.entries(properties)) {
+        await expect(element).toHaveCSS(property, value);
+    }
+};
+
+const getComputedStyleProperty = async (element, property) => {
+    return await element.evaluate((el, prop) =>
+        window.getComputedStyle(el).getPropertyValue(prop),
+        property
+    );
+};
+
+test("Vérifiez si les propriétés CSS sont correctement définies", async ({ browser }) => {
+    const context = await browser.newContext();
+    await context.addCookies([await getLoggedCookies()]);
+    const page = await context.newPage();
+    await page.goto('/css-template');
+
+    const title = page.locator('h1');
+    const secondTitle = page.locator('h2');
+    const formDiv = page.locator('#formTest');
+    const link = page.locator('a');
+    const mainDiv = page.locator('#mainDiv');
+    const greenButton = page.locator('#green-button');
+    const redButton = page.locator('#red-button');
+    const basicButton = page.locator('#basic-button');
+    const basicInput = page.locator('input');
+
+    const linkColor = await getComputedStyleProperty(link.nth(0), 'color');
+    const greenButtonColor = await getComputedStyleProperty(greenButton, 'background-color');
+    const redButtonColor = await getComputedStyleProperty(redButton, 'background-color');
+    const basicButtonColor = await getComputedStyleProperty(basicButton, 'background-color');
+    const divColor = await getComputedStyleProperty(mainDiv, 'background-color');
+    const formColor = await getComputedStyleProperty(formDiv, 'background-color');
+    const formBorderColor = await getComputedStyleProperty(formDiv, 'border-color');
+    const inputColor = await getComputedStyleProperty(basicInput, 'background-color');
+
+    // Test title properties
+    await testCSSProperties(title, {
+        'font-size': '30px',
+        'line-height': '36px',
+        'font-weight': '700',
+    });
+
+    // Test h2 title properties
+    await testCSSProperties(secondTitle, {
+        'font-size': '24px',
+        'line-height': '28px',
+    });
+
+    // Test div properties
+    expect(divColor).toBe('rgb(0, 11, 29)');
+    await testCSSProperties(mainDiv, {
+        'text-align': 'center',
+    });
+
+    // Test form properties
+    expect(formColor).toBe('rgb(31, 41, 55)');
+    expect(formBorderColor).toBe('rgb(55, 65, 81)');
+    await testCSSProperties(formDiv, {
+        'border-radius': '8px',
+        'padding': '15px',
+    });
+
+    // Test globalInput properties
+    await testCSSProperties(basicInput, {
+        'margin': '5px',
+        'text-align': 'left',
+        'cursor': 'text',
+        'border-radius': '8px',
+        'height': '40px',
+    });
+
+    // Test button properties
+    await testCSSProperties(basicButton, {
+        'height': '35px',
+        'border-radius': '17.5px',
+        'margin': '5px',
+        'outline': 'rgb(255, 255, 255) none 0px',
+        'border': '0px none rgb(255, 255, 255)',
+        'font-family': 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
+        'padding': '0px 15px',
+        'background-repeat': 'no-repeat',
+        'cursor': 'pointer',
+        'box-sizing': 'border-box',
+    });
+    expect(basicButtonColor).toBe('rgb(59, 130, 246)');
+
+    // Test link properties
+    expect(linkColor).toBe('rgb(255, 255, 255)');
+
+    // Test green and red button color properties 
+    expect(greenButtonColor).toBe('rgb(22, 163, 74)');
+    expect(redButtonColor).toBe('rgb(220, 38, 38)');
+});
+
+async function getSessionUuid() {
+    const pool = getTempPool();
+    const { rows } = await pool.query({
+        text: 'SELECT uuid FROM sessions WHERE expires_at > CURRENT_TIMESTAMP;',
+        values: []
+    });
+    pool.end();
+    return rows[0].uuid;
+}
+
+function getTempPool() {
+    return new Pool({
+        host: process.env.POSTGRES_HOST || 'localhost',
+        port: process.env.POSTGRES_PORT || 5432,
+        database: process.env.POSTGRES_DATABASE || 'pocketbot',
+        user: process.env.POSTGRES_USER || 'postgres',
+        password: process.env.POSTGRES_PASSWORD || 'postgres'
+    });
+}
+
+async function getLoggedCookies() {
+    const sessionUuid = await getSessionUuid();
+    return {
+        name: 'uuid',
+        value: sessionUuid,
+        domain: 'localhost',
+        path: '/',
+        expires: -1
+    };
+}

--- a/services/web/svelte-kit/tests/utils.js
+++ b/services/web/svelte-kit/tests/utils.js
@@ -1,0 +1,122 @@
+import pkg from 'pg';
+const {Pool} = pkg;
+import * as crypto from 'crypto';
+import { getTypeName } from 'eslint-plugin-svelte/lib/utils/ts-utils/index.js';
+
+export const POSTGRES_HOST = process.env.POSTGRES_HOST || 'localhost';
+export const POSTGRES_PORT = process.env.POSTGRES_PORT || 5432;
+export const POSTGRES_DATABASE = process.env.POSTGRES_DATABASE || 'postgres';
+export const POSTGRES_USER = process.env.POSTGRES_USER || 'postgres';
+export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD || 'postgres';
+
+export function getTempPool() {
+	return new Pool({
+		host: process.env.POSTGRES_HOST || 'localhost',
+		port: process.env.POSTGRES_PORT || 5432,
+		database: process.env.POSTGRES_DATABASE || 'postgres',
+		user: process.env.POSTGRES_USER || 'postgres',
+		password: process.env.POSTGRES_PASSWORD || 'postgres'
+	});
+}
+
+export async function getSessionUuid(username) {
+    const pool = getTempPool();
+    const {rows} = await pool.query({
+        text: 'SELECT uuid FROM sessions AS "s" JOIN users AS "u" ON s.user_id=u.user_id  WHERE expires_at > CURRENT_TIMESTAMP AND u.username=$1;',
+        values: [username]
+    });
+    pool.end();
+    return rows[0].uuid;
+}
+
+export async function getLoggedCookies(username) {
+    const sessionUuid = await getSessionUuid(username);
+    return {
+        name: 'uuid',
+        value: sessionUuid,
+        domain: 'localhost',
+        path: '/',
+        expires: -1
+    };
+}
+
+export async function getUserInfo() {
+	const {rows} = await getTempPool().query({
+		text: 'SELECT user_id, username FROM users LIMIT 1;',
+		values: []
+	});
+	console.log(rows)
+	return rows[0];
+}
+
+export async function getLocals() {
+	const locals = {};
+	locals.pool = getTempPool();
+	locals.userInfo = await getUserInfo();
+	return locals;
+}
+
+export async function deleteUserByUsername(username) {
+	await getTempPool().query({
+		text: 'DELETE FROM users WHERE username=$1',
+		values: [username]
+	});
+}
+
+export async function insertSomeParts(userId) {
+	await getTempPool().query({
+		text:
+			'INSERT INTO archive_parts (winner, loser, duration_ms, date)\n' +
+			'VALUES\n' +
+			'    ((SELECT user_id FROM users WHERE user_id != $1 LIMIT 1), $1, 10000, CURRENT_TIMESTAMP),\n' +
+			'    ((SELECT user_id FROM users WHERE user_id != $1 LIMIT 1), $1, 10000, CURRENT_TIMESTAMP + INTERVAL \'1\' DAY),\n' +
+			'    ((SELECT user_id FROM users WHERE user_id != $1 LIMIT 1), $1, 10000, CURRENT_TIMESTAMP + INTERVAL \'2\' DAY),\n' +
+			'    ((SELECT user_id FROM users WHERE user_id != $1 LIMIT 1), $1, 10000, CURRENT_TIMESTAMP + INTERVAL \'3\' DAY);',
+		values: [userId]
+	});
+}
+
+export async function deletePartsOf(userId) {
+	await getTempPool().query({
+		text: 'DELETE FROM archive_parts WHERE winner=$1 OR loser=$1;',
+		values: [userId]
+	});
+}
+
+export async function createDbSessions(userId) {
+	await getTempPool().query({
+		text: 'INSERT INTO sessions (user_id, uuid, expires_at) VALUES ($1, $2, CURRENT_TIMESTAMP + INTERVAL \'3\' DAY);',
+		values: [userId, crypto.randomUUID()]
+	});
+}
+
+export async function getDbSessions(userId) {
+	const {rows} = await getTempPool().query({
+		text: 'SELECT * FROM sessions WHERE user_id=$1;',
+		values: [userId]
+	});
+	return rows;
+}
+
+export async function getTableDataOfUsers(username) {
+	const {rows} = await getTempPool().query({
+		text: 'SELECT * FROM users WHERE username=$1 LIMIT 1;',
+		values: [username]
+	});
+	return rows[0];
+}
+
+export async function setAdminFromUsername(username) {
+    await getTempPool().query({
+        text: 'INSERT INTO users_roles (user_id, role_id) VALUES ((SELECT user_id FROM users WHERE username=$1), 2);',
+        values: [username]
+    });
+}
+
+export async function insertSession(username) {
+    await getTempPool().query({
+        text: 'INSERT INTO sessions (user_id, uuid, expires_at) VALUES ((SELECT user_id FROM users WHERE username=$1), $2, CURRENT_TIMESTAMP + INTERVAL \'2\' DAY);',
+        values: [username, crypto.randomUUID()]
+    });
+}
+


### PR DESCRIPTION
Add a global style for all pages in `app.css` file.

The style foundation is defined globally for the site but there are still a few steps to complete this feature: define the css correctly on the other pages in relation to the global css and remove tailwind from the other pages and from the global css file.
A page `/css-template` has been added to test the all differents global style.

Tests: Tests have been added and used on the same page  `/css-template`. To test this feature we simulate a logged-in user taking a valid session from the database. A temporary pool is created to obtain the uuid as the tests do not understand imports such as `$lib` or `$env`. It is also necessary to ensure that an `.env` file is present at the root of the project.

Launching the tests: The site must be launched in the background and then install playwright `npx playwright install` and launch the tests with `npx playwright` test.