### PR TITLE
Fermeture du port 5432 ouvert à Internet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       dockerfile: Dockerfile
     restart: always
     container_name: postgres
-    ports:
-      - "5432:5432"
 
   svelte-kit:
     build:

--- a/services/database/Dockerfile
+++ b/services/database/Dockerfile
@@ -4,5 +4,7 @@ ENV POSTGRES_PASSWORD=2jP0iPXZcAsRRP2IP8zfTYW1U
 ENV POSTGRES_USER=pocketuser
 ENV POSTGRES_DB=pocketbot
 
+EXPOSE 5432
+
 COPY scripts/schema.sql /docker-entrypoint-initdb.d/
 


### PR DESCRIPTION
## Description :
Le port du container de la base de données (5432) était ouvert à Internet, ce qui était une faille de sécurité. Maintenant, le port est uniquement accessible aux containers du docker compose.