### PR TITLE
Ajout de tests pour les rôles

### DIFF
--- a/services/web/svelte-kit/tests/unit/spec/roles.spec.js
+++ b/services/web/svelte-kit/tests/unit/spec/roles.spec.js
@@ -1,20 +1,5 @@
-import {
-	checkFormFields,
-	checkIfPasswordIsCorrect, checkIfUsernameExists,
-	createUser, deleteDbSession,
-	generateUuid, getArchiveParts, getUserId, getUserRoles,
-	hashPassword, softDeleteUser,
-	usernameToId
-} from '$lib/server/account.js';
-import {
-	createDbSessions,
-	deletePartsOf,
-	deleteUserByUsername, getDbSessions,
-	getLocals, getTableDataOfUsers, getTempPool,
-	insertSomeParts
-} from '../../utils.js';
-import * as argon2 from "argon2";
-import * as crypto from 'crypto';
+import { createUser, usernameToId } from '$lib/server/account.js';
+import { deleteUserByUsername, getLocals } from '../../utils.js';
 
 describe("Test roles table", async () => {
     const locals = await getLocals();

--- a/services/web/svelte-kit/tests/unit/spec/roles.spec.js
+++ b/services/web/svelte-kit/tests/unit/spec/roles.spec.js
@@ -1,0 +1,72 @@
+import {
+	checkFormFields,
+	checkIfPasswordIsCorrect, checkIfUsernameExists,
+	createUser, deleteDbSession,
+	generateUuid, getArchiveParts, getUserId, getUserRoles,
+	hashPassword, softDeleteUser,
+	usernameToId
+} from '$lib/server/account.js';
+import {
+	createDbSessions,
+	deletePartsOf,
+	deleteUserByUsername, getDbSessions,
+	getLocals, getTableDataOfUsers, getTempPool,
+	insertSomeParts
+} from '../../utils.js';
+import * as argon2 from "argon2";
+import * as crypto from 'crypto';
+
+describe("Test roles table", async () => {
+    const locals = await getLocals();
+
+    it("Check roles table exists", async () => {
+        const { rows } = await locals.pool.query("SELECT * FROM roles");
+        expect(rows).toBeTruthy();
+    });
+
+    it("Check roles table is well formed", async () => {
+        const { rows } = await locals.pool.query("SELECT * FROM roles");
+        expect(rows[0]).toHaveProperty('role_id');
+        expect(rows[0]).toHaveProperty('name');
+        expect(Object.keys(rows[0])).toHaveLength(2);
+    });
+});
+
+describe("Test users_roles table", async () => {
+    const locals = await getLocals();
+
+    it("Check users_roles table exists", async () => {
+        const { rows } = await locals.pool.query("SELECT * FROM users_roles");
+        expect(rows).toBeTruthy();
+    });
+
+    it("Check users_roles table is well formed", async () => {
+        const { rows } = await locals.pool.query("SELECT * FROM users_roles");
+        expect(rows[0]).toHaveProperty('user_id');
+        expect(rows[0]).toHaveProperty('role_id');
+        expect(Object.keys(rows[0])).toHaveLength(2);
+    });
+});
+
+describe("Test mandatory roles", async () => {
+    const locals = await getLocals();
+
+    it("Check if the mandatory roles are present and have the correct ids", async () => {
+        const expectedRoles = [{role_id: 0, name: 'suspended'}, {role_id: 1, name: 'user'}, {role_id: 2, name: 'admin'}];
+        const { rows } = await locals.pool.query("SELECT * FROM roles");
+        expect(rows).toEqual(expect.arrayContaining(expectedRoles));
+    });
+});
+
+describe("Test user creation", async () => {
+    const locals = await getLocals();
+
+    it("Check user creation includes 'user' role", async () => {
+        const username = "a_cool_username"
+        expect(await createUser(locals, username, "a_valid_Passw0rd"));
+        const userId = await usernameToId(username);
+        const { rows } = await locals.pool.query("SELECT * FROM users_roles WHERE user_id = $1", [userId]);
+        expect(rows).toEqual(expect.arrayContaining([{user_id: userId, role_id: 1}]));
+        await deleteUserByUsername(username)
+    });
+});

--- a/services/web/svelte-kit/tests/unit/spec/roles.spec.js
+++ b/services/web/svelte-kit/tests/unit/spec/roles.spec.js
@@ -47,11 +47,11 @@ describe("Test user creation", async () => {
     const locals = await getLocals();
 
     it("Check user creation includes 'user' role", async () => {
-        const username = "a_cool_username"
+        const username = "a_cool_username";
         expect(await createUser(locals, username, "a_valid_Passw0rd"));
         const userId = await usernameToId(username);
         const { rows } = await locals.pool.query("SELECT * FROM users_roles WHERE user_id = $1", [userId]);
         expect(rows).toEqual(expect.arrayContaining([{user_id: userId, role_id: 1}]));
-        await deleteUserByUsername(username)
+        await deleteUserByUsername(username);
     });
 });


### PR DESCRIPTION
Cette PR permet l'ajout de tests afin de vérifier le bon fonctionnement des rôles ajoutés dans #53 #54.

Les tests effectués vérifient : 
- La table 'roles' existe et est formée correctement. Le nombre de colonnes doit être exacte et leurs noms aussi. 
- La table 'users_roles' existe et est formée correctement. Le nombre de colonnes doit être exacte et leurs noms aussi.
- Les rôles nécessaires au bon fonctionnement du code sont présents. Il y a trois rôles qui sont toujours présents et qui doivent avoir le même `role_id` et `name`.
- Lors de la création d'un utilisateur, le rôle `user` lui est correctement assigné.

### Lancer les tests
Afin de pouvoir vérifier le fonctionnement des tests, assurez vous d'abord d'avoir démarré la base de données. Il vous suffit ensuite d'executer `npm run test:unit`.